### PR TITLE
Add show one dispensary page

### DIFF
--- a/src/routes/dispensary/[id]/+page.svelte
+++ b/src/routes/dispensary/[id]/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+    export let data
+    const dispensary = data.dispensaryQuery.data
+</script>
+
+<h1>Show Dispensary</h1>
+{#if !dispensary}
+    <div>No record found</div>
+{/if}
+{#if dispensary}
+    <div>
+        <h1>{dispensary.name}</h1>
+        <h3>{dispensary.address_1}</h3>
+    </div>
+{/if}

--- a/src/routes/dispensary/[id]/+page.ts
+++ b/src/routes/dispensary/[id]/+page.ts
@@ -1,0 +1,12 @@
+import supabase from '$lib/supabase/client'
+import type { Load } from '@sveltejs/kit'
+
+export const load: Load = async ({ params }) => {
+    return {
+        dispensaryQuery: await supabase
+            .from('dispensary')
+            .select('*')
+            .eq('id', params.id)
+            .maybeSingle(),
+    }
+}


### PR DESCRIPTION
Simple new page, but highlights the use of:
* Routing parameters (https://kit.svelte.dev/docs/routing#page)
* Supabase query with a filtering "where" clause (https://supabase.com/docs/reference/javascript/maybesingle)

<img width="796" alt="image" src="https://github.com/win-sol-fusion/hazy-goods-web/assets/84503075/b2d78e9c-3621-4e56-bb33-f2bb6acc0d06">
