### PR TITLE
Put the AppRail in the sidebarLeft slot of the AppShell

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,37 +26,38 @@
         <AppBar>Hazy Goods</AppBar>
     </svelte:fragment>
 
-    <AppRail>
-        <svelte:fragment slot="lead">
-            <AppRailAnchor href="/">
-                <div class="ml-7">
-                    <Icon
-                        src={BuildingStorefront}
-                        size="20px"
-                        theme="outline"
-                    />
-                </div>
-                Home</AppRailAnchor
-            >
-            <AppRailAnchor href="/dispensary">
-                <div class="ml-7">
-                    <Icon
-                        src={ClipboardDocumentList}
-                        size="20px"
-                        theme="outline"
-                    />
-                </div>
-                Dispensary List</AppRailAnchor
-            >
-            <AppRailAnchor href="/dispensary/add">
-                <div class="ml-7">
-                    <Icon src={PlusCircle} size="20px" theme="outline" />
-                </div>
-                Add New Dispensary</AppRailAnchor
-            >
-        </svelte:fragment>
-    </AppRail>
-    <main>
-        <slot />
-    </main>
+    <svelte:fragment slot="sidebarLeft">
+        <AppRail>
+            <svelte:fragment slot="lead">
+                <AppRailAnchor href="/">
+                    <div class="ml-7">
+                        <Icon
+                            src={BuildingStorefront}
+                            size="20px"
+                            theme="outline"
+                        />
+                    </div>
+                    Home
+                </AppRailAnchor>
+                <AppRailAnchor href="/dispensary">
+                    <div class="ml-7">
+                        <Icon
+                            src={ClipboardDocumentList}
+                            size="20px"
+                            theme="outline"
+                        />
+                    </div>
+                    Dispensary List
+                </AppRailAnchor>
+                <AppRailAnchor href="/dispensary/add">
+                    <div class="ml-7">
+                        <Icon src={PlusCircle} size="20px" theme="outline" />
+                    </div>
+                    Add New Dispensary
+                </AppRailAnchor>
+            </svelte:fragment>
+        </AppRail>
+    </svelte:fragment>
+
+    <slot />
 </AppShell>


### PR DESCRIPTION
Found this in the Skeleton UI docs for App Shell:
![image](https://github.com/win-sol-fusion/hazy-goods-web/assets/84503075/c0b9181c-618d-41fd-ae7b-313a1f91956f)

Looks better now:
![image](https://github.com/win-sol-fusion/hazy-goods-web/assets/84503075/fa0a374f-4583-4f4c-bb60-a1e310ee170f)
